### PR TITLE
Moved score, accuracy + misses text info text below the hp bar for downscroll

### DIFF
--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -354,6 +354,14 @@ class PlayState extends MusicBeatState
 		missesTxt = new FunkinText(healthBarBG.x + 50, healthBarBG.y + 30, Std.int(healthBarBG.width - 100), "Misses:0", 16);
 		accuracyTxt = new FunkinText(healthBarBG.x + 50, healthBarBG.y + 30, Std.int(healthBarBG.width - 100), "Acc:-% (N/A)", 16);
 		accuracyTxt.addFormat(accFormat, 0, 1);
+		
+		  if(Options.downscroll)
+			{
+				scoreTxt.y -= 60;
+				missesTxt.y -= 60;
+				accuracyTxt.y -= 60;
+			}
+
 
 		for(text in [scoreTxt, missesTxt, accuracyTxt]) {
 			text.scrollFactor.set();


### PR DESCRIPTION
Having the info text below the hp bar when downscroll is on to make it a bit more easier to read than having it on top of the healthbar